### PR TITLE
Loosen the deps requirements a little

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-click==7.1.2
-rzpipe==0.1.0
-pyyaml==5.4.1
+click~=8.0.0
+rzpipe~=0.1.0
+pyyaml~=5.4.1


### PR DESCRIPTION
Any project using uefi-r2 can't update to the latest deps (for other
fixes) as explict versions are being used. Use fuzzy equality so that
we can install rzpipe in 0.1.0, 0.1.1 or 0.1.2 versions without worry.