### PR TITLE
fix rzpipe version to 0.1.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 click~=8.0.0
-rzpipe~=0.1.0
+rzpipe==0.1.0
 pyyaml~=5.4.1


### PR DESCRIPTION
Version 0.1.2 renamed the kw arg rizinhome to rizin_home.