### PR TITLE
Fixes for latest rizin

### DIFF
--- a/uefi_r2/uefi_analyzer.py
+++ b/uefi_r2/uefi_analyzer.py
@@ -228,7 +228,7 @@ class UefiAnalyzer:
 
         for func in self.functions:
             func_addr = func["offset"]
-            func_insns = self._rz.cmdj("pdfj @{:#x}".format(func_addr))
+            func_insns = self._rz.cmdj("pdfj @ {:#x}".format(func_addr))
             g_bs_reg = None
             for insn in func_insns["ops"]:
                 if "esil" in insn:
@@ -264,7 +264,7 @@ class UefiAnalyzer:
 
         for func in self.functions:
             func_addr = func["offset"]
-            func_insns = self._rz.cmdj("pdfj @{:#x}".format(func_addr))
+            func_insns = self._rz.cmdj("pdfj @ {:#x}".format(func_addr))
             g_rt_reg = None
             for insn in func_insns["ops"]:
                 if "esil" in insn:
@@ -449,7 +449,7 @@ class UefiAnalyzer:
     def _get_protocols_64bit(self) -> List[UefiProtocol]:
         protocols = list()
         for bs in self.boot_services_protocols:
-            block_insns = self._rz.cmd("pdbj @{:#x}".format(bs.address))
+            block_insns = self._rz.cmd("pdbj @ {:#x}".format(bs.address))
             try:
                 block_insns = json.loads(block_insns)
             except (ValueError, KeyError, TypeError) as _:
@@ -535,7 +535,7 @@ class UefiAnalyzer:
         for service in self.runtime_services:
             if service.name in ["GetVariable", "SetVariable"]:
                 # disassemble 8 instructions backward
-                block_insns = self._rz.cmdj("pdj -8 @{:#x}".format(service.address))
+                block_insns = self._rz.cmdj("pdj -8 @ {:#x}".format(service.address))
                 name: str = str()
                 p_guid_b: bytes = bytes()
                 for index in range(len(block_insns) - 2, -1, -1):
@@ -553,14 +553,14 @@ class UefiAnalyzer:
                         and (esil[-3] == "+")
                         and (esil[-4] == "rip")
                     ):
-                        name = self._rz.cmd("psw @{:#x}".format(ref_addr))[:-1]
+                        name = self._rz.cmd("psw @ {:#x}".format(ref_addr))[:-1]
                     if (
                         (esil[-1] == "=")
                         and (esil[-2] == "rdx")
                         and (esil[-3] == "+")
                         and (esil[-4] == "rip")
                     ):
-                        p_guid_b = bytes(self._rz.cmdj("xj 16 @{:#x}".format(ref_addr)))
+                        p_guid_b = bytes(self._rz.cmdj("xj 16 @ {:#x}".format(ref_addr)))
                     if not name:
                         name = "Unknown"
                     if p_guid_b:
@@ -583,7 +583,7 @@ class UefiAnalyzer:
         pei_list: List[UefiService] = list()
         for func in self.functions:
             func_addr = func["offset"]
-            func_insns = self._rz.cmdj("pdfj @{:#x}".format(func_addr))
+            func_insns = self._rz.cmdj("pdfj @ {:#x}".format(func_addr))
             for insn in func_insns["ops"]:
                 if "esil" not in insn:
                     continue
@@ -622,7 +622,7 @@ class UefiAnalyzer:
         for pei_service in self.pei_services:
             if pei_service.name != "LocatePpi":
                 continue
-            block_insns = self._rz.cmdj("pdj -16 @{:#x}".format(pei_service.address))
+            block_insns = self._rz.cmdj("pdj -16 @ {:#x}".format(pei_service.address))
             for index in range(len(block_insns) - 1, -1, -1):
                 esil = block_insns[index]["esil"].split(",")
                 if not (esil[-1] == "-=" and esil[-2] == "esp" and esil[-3] == "4"):


### PR DESCRIPTION
Fixes the following bug, which occurs when running `uefi_r2_analyzer.py analyze-image ...` with the latest Rizin (tested against rizinorg/rizin/dev@ce262c485b667e3e2ecbcbbbf0f12070ecbcb9e4):

```.sh
  File "/home/slt/projects/uefi-r2-orig/uefi_r2_analyzer.py", line 38, in analyze_image
    summary = uefi_analyzer.get_summary()
  File "/home/slt/projects/uefi-r2-orig/uefi_r2/uefi_analyzer.py", line 714, in get_summary
    summary["g_bs"] = self.g_bs
  File "/home/slt/projects/uefi-r2-orig/uefi_r2/uefi_analyzer.py", line 259, in g_bs
    self._g_bs = self._get_bs_64bit()
  File "/home/slt/projects/uefi-r2-orig/uefi_r2/uefi_analyzer.py", line 233, in _get_bs_64bit
    for insn in func_insns["ops"]:
TypeError: 'NoneType' object is not subscriptable
```

The root cause seems to be due to changes in how Rizin parses commands.