### PR TITLE
Multi rule scanner

### DIFF
--- a/uefi_r2/__init__.py
+++ b/uefi_r2/__init__.py
@@ -9,13 +9,14 @@ __email__ = "yegor@binarly.io"
 __version__ = "1.2.0"
 
 from .uefi_analyzer import UefiAnalyzer, UefiAnalyzerError
-from .uefi_scanner import UefiRule, UefiScanner
+from .uefi_scanner import UefiRule, UefiScanner, UefiMultiScanner
 from .uefi_te import TerseExecutableParser
 
 __all__ = [
     "UefiAnalyzer",
     "UefiRule",
     "UefiScanner",
+    "UefiMultiScanner",
     "TerseExecutableParser",
     "UefiAnalyzerError",
 ]

--- a/uefi_r2_analyzer.py
+++ b/uefi_r2_analyzer.py
@@ -12,7 +12,7 @@ from typing import List
 
 import click
 
-from uefi_r2 import UefiAnalyzer, UefiRule, UefiScanner
+from uefi_r2 import UefiAnalyzer, UefiRule, UefiScanner, UefiMultiScanner
 
 
 @click.group()
@@ -48,15 +48,17 @@ def analyze_image(image_path: str, out: str) -> bool:
 
 @click.command()
 @click.argument("image_path")
-@click.option("-r", "--rule", help="The path to the rule.")
-def scan(image_path: str, rule: str) -> bool:
+@click.option("-r", "--rule", help="The path to the rule.", multiple=True)
+def scan(image_path: str, rule: List[str]) -> bool:
     """Scan input UEFI image."""
+
+    rules = rule
 
     if not os.path.isfile(image_path):
         print("{} check image path".format(click.style("ERROR", fg="red", bold=True)))
         return False
-    if not (rule and os.path.isfile(rule)):
-        print("{} check rule path".format(click.style("ERROR", fg="red", bold=True)))
+    if not all(rule and os.path.isfile(rule) for rule in rules):
+        print("{} check rule(s) path".format(click.style("ERROR", fg="red", bold=True)))
         return False
 
     # on linux platforms you can pass blob via shm://
@@ -64,39 +66,61 @@ def scan(image_path: str, rule: str) -> bool:
 
     uefi_analyzer = UefiAnalyzer(image_path=image_path)
 
-    with open(rule, "r") as f:
-        rule_content = f.read()
+    uefi_rules: List[UefiRule] = list()
 
-    uefi_rule = UefiRule(rule_content=rule_content)
-    prefix = click.style("UEFI rule", fg="green")
-    if len(uefi_rule.nvram_vars):
-        print(f"{prefix} nvram: {[x.__dict__ for x in uefi_rule.nvram_vars]}")
-    if len(uefi_rule.protocols):
-        print(f"{prefix} protocols: {[x.__dict__ for x in uefi_rule.protocols]}")
-    if len(uefi_rule.ppi_list):
-        print(f"{prefix} ppi: {[x.__dict__ for x in uefi_rule.ppi_list]}")
-    if len(uefi_rule.protocol_guids):
-        print(f"{prefix} guids: {[x.__dict__ for x in uefi_rule.protocol_guids]}")
-    if len(uefi_rule.esil_rules):
-        print(f"{prefix} esil: {uefi_rule.esil_rules}")
-    if len(uefi_rule.strings):
-        print(f"{prefix} strings: {uefi_rule.strings}")
-    if len(uefi_rule.wide_strings):
-        print(f"{prefix} wide_strings: {uefi_rule.wide_strings}")
-    if len(uefi_rule.hex_strings):
-        print(f"{prefix} hex_strings: {uefi_rule.hex_strings}")
-    if len(uefi_rule.code):
-        for code in uefi_rule.code:
-            print(f"{prefix} code: {code.__dict__}")
+    for r in rules:
+        with open(r, "r") as f:
+            rule_content = f.read()
 
-    scanner = UefiScanner(uefi_analyzer, uefi_rule)
-    prefix = click.style("Scanner result", fg="green")
-    res = click.style("No threats detected", fg="green")
-    if scanner.result:
-        res = click.style(
+        uefi_rule = UefiRule(rule_content=rule_content)
+        prefix = click.style("UEFI rule", fg="green")
+        if len(uefi_rule.nvram_vars):
+            print(f"{prefix} nvram: {[x.__dict__ for x in uefi_rule.nvram_vars]}")
+        if len(uefi_rule.protocols):
+            print(f"{prefix} protocols: {[x.__dict__ for x in uefi_rule.protocols]}")
+        if len(uefi_rule.ppi_list):
+            print(f"{prefix} ppi: {[x.__dict__ for x in uefi_rule.ppi_list]}")
+        if len(uefi_rule.protocol_guids):
+            print(f"{prefix} guids: {[x.__dict__ for x in uefi_rule.protocol_guids]}")
+        if len(uefi_rule.esil_rules):
+            print(f"{prefix} esil: {uefi_rule.esil_rules}")
+        if len(uefi_rule.strings):
+            print(f"{prefix} strings: {uefi_rule.strings}")
+        if len(uefi_rule.wide_strings):
+            print(f"{prefix} wide_strings: {uefi_rule.wide_strings}")
+        if len(uefi_rule.hex_strings):
+            print(f"{prefix} hex_strings: {uefi_rule.hex_strings}")
+        if len(uefi_rule.code):
+            for code in uefi_rule.code:
+                print(f"{prefix} code: {code.__dict__}")
+
+        uefi_rules.append(uefi_rule)
+
+    if len(uefi_rules) > 1:
+        scanner = UefiMultiScanner(uefi_analyzer, uefi_rules)
+        prefix = click.style("Scanner result", fg="green")
+
+        no_threat = click.style("No threat detected", fg="green")
+        threat = click.style(
             "FwHunt rule has been triggered and threat detected!", fg="red"
         )
-    print(f"{prefix} {uefi_rule.name} {res} ({image_path})")
+
+        results = scanner.results
+        for i, uefi_rule in enumerate(uefi_rules):
+            if i in results:
+                print(f"{prefix} {uefi_rule.name} {threat} ({image_path})")
+            else:
+                print(f"{prefix} {uefi_rule.name} {no_threat} ({image_path})")
+    else:
+        uefi_rule = uefi_rules[0]
+        scanner = UefiScanner(uefi_analyzer, uefi_rule)
+        prefix = click.style("Scanner result", fg="green")
+        res = click.style("No threats detected", fg="green")
+        if scanner.result:
+            res = click.style(
+                "FwHunt rule has been triggered and threat detected!", fg="red"
+            )
+        print(f"{prefix} {uefi_rule.name} {res} ({image_path})")
 
     uefi_analyzer.close()
 


### PR DESCRIPTION
Adds a class `UefiMultiScanner`, which can match multiple rules simultaneously. It attempts to avoid duplicating work by finding common properties amongst rules and checking for them only once.

A `UefiMultiScanner` takes a list of rules and produces a set of indices in its `results` field corresponding to matched rules from the input list.