### PR TITLE
Allow getting the license from the meta block

### DIFF
--- a/uefi_r2/uefi_scanner.py
+++ b/uefi_r2/uefi_scanner.py
@@ -138,6 +138,15 @@ class UefiRule:
             return None
 
     @property
+    def license(self) -> Optional[str]:
+        """Get rule license from the metadata block"""
+
+        try:
+            return self._uefi_rule["meta"]["license"]
+        except KeyError:
+            return None
+
+    @property
     def cve_number(self) -> Optional[str]:
         """Get CVE number from the metadata block"""
 


### PR DESCRIPTION
The idea here is that yml files will have a section like:

    FooBar:
      meta:
        author: Person <person@company.com>
        license: CC0-1.0