### PR TITLE
Allow getting the possible UEFI volume GUIDs from the rule

### DIFF
--- a/uefi_r2/uefi_scanner.py
+++ b/uefi_r2/uefi_scanner.py
@@ -147,6 +147,15 @@ class UefiRule:
             return None
 
     @property
+    def volume_guids(self) -> Optional[List[str]]:
+        """Get any volume GUIDs from the metadata block"""
+
+        try:
+            return self._uefi_rule["meta"]["volume guids"]
+        except KeyError:
+            return None
+
+    @property
     def vendor_id(self) -> Optional[str]:
         """Get vendor id from the metadata block"""
 

--- a/uefi_r2_analyzer.py
+++ b/uefi_r2_analyzer.py
@@ -90,6 +90,8 @@ def scan(image_path: str, rule: List[str]) -> bool:
             print(f"{prefix} wide_strings: {uefi_rule.wide_strings}")
         if len(uefi_rule.hex_strings):
             print(f"{prefix} hex_strings: {uefi_rule.hex_strings}")
+        if uefi_rule.volume_guids:
+            print(f"{prefix} volume_guids: {uefi_rule.volume_guids}")
         if len(uefi_rule.code):
             for code in uefi_rule.code:
                 print(f"{prefix} code: {code.__dict__}")


### PR DESCRIPTION
The idea here is that the rule can specify an optional hint on which
volume GUIDs should be matched. This means we only have to scan one EFI
binary per firmware, rather than potentially hundreds. There's no point
looking for ThinkPwn on LegacySpeakerDxe for example.

Using this hint means it takes a few seconds to scan each firmware on
the LVFS, rather than more than ~2 minutes -- which takes the query time
down from 19 hours per new rule [!!!], to ~40 minutes when scanning all
public firmware files with a new uefi_r2 rule.

This would be specified like this:

    FooBar:
      meta:
        volume guids:
          - dcd13040-23d8-41c6-b8f5-22281a0d64e8