### PR TITLE
trivial: Reduce the click dep level

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-click~=8.0.0
+click>=7
 rzpipe==0.1.2
 pyyaml~=5.4.1


### PR DESCRIPTION
This prevents this from projects *using* uefi_r2:

    celery 5.1.2 depends on click<8.0 and >=7.0
    click-didyoumean 0.3.0 depends on click>=7
    click-repl 0.2.0 depends on click
    flask 2.0.2 depends on click>=7.1.2
    uefi-r2 1.2.0 depends on click~=8.0.0

Fixes https://github.com/binarly-io/uefi_r2/issues/36