### PR TITLE
Fix for multi-scanner bug

### DIFF
--- a/uefi_r2/uefi_scanner.py
+++ b/uefi_r2/uefi_scanner.py
@@ -1246,8 +1246,10 @@ class UefiMultiScanner:
                         res &= child_sw_smi_handler_res
                         if not res:
                             break
+                    if not res:
+                        break
 
-                matches = self._update_index_match(matches, i, res)
+            matches = self._update_index_match(matches, i, res)
 
         return matches
 


### PR DESCRIPTION
Fixes a bug in `UefiMultiScanner` that causes rules relying on `_code_scanner` to incorrectly report matches in some cases.